### PR TITLE
feat: support dual package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,5 @@ fabric.properties
 # Build files
 /lib
 /module
+/module/
+/lib/

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@types/node": "^18.11.18",
         "ts-node": "^10.9.1",
+        "tsconfig-to-dual-package": "^1.0.7",
         "typescript": "^4.9.4"
       }
     },
@@ -69,8 +70,9 @@
     },
     "node_modules/@types/node": {
       "version": "18.11.18",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
+      "dev": true
     },
     "node_modules/acorn": {
       "version": "8.8.1",
@@ -106,10 +108,27 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/resolve-tsconfig": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/resolve-tsconfig/-/resolve-tsconfig-1.3.0.tgz",
+      "integrity": "sha512-Ba5mo3soshb2CnIcNFz75F/80H/2eMVxrlmdgoSDNH7Lr6UAoT3BvxNtc7+VXqKSBlC0SJk2qSXOTcy0/p7cFw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16",
+        "pnpm": ">=7"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/skarab42"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      }
+    },
     "node_modules/ts-node": {
       "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -156,10 +175,26 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/tsconfig-to-dual-package": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/tsconfig-to-dual-package/-/tsconfig-to-dual-package-1.0.7.tgz",
+      "integrity": "sha512-LVGvjHTnN8F9+Cu51es09YHh4zxqiycoJjX0g54OSeQLvLPC7ix1j5kxWKcqLtgt4YiRVgNt19sg3wdxjHq4NA==",
+      "dev": true,
+      "dependencies": {
+        "resolve-tsconfig": "^1.3.0"
+      },
+      "bin": {
+        "tsconfig-to-dual-package": "bin/cmd.mjs"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.0.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "build": "tsc -p ./tsconfig.json && tsc -p ./tsconfig.cjs.json && tsconfig-to-dual-package",
     "clean": "git clean -fx lib/ module/",
     "prepublishOnly": "npm run build",
-    "test": "node --test --require ts-node/esm ./test/*.ts",
+    "test": "node --test --loader ts-node/esm ./test/*.ts",
     "watch": "tsc -p . --watch"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,9 +19,19 @@
   "license": "MIT",
   "author": "azu",
   "sideEffects": false,
-  "main": "./lib/index.js",
-  "module": "./module/index.js",
-  "types": "./lib/index.d.ts",
+  "type": "module",
+  "main": "./lib/tsconfig-to-dual-package-example.js",
+  "module": "./module/tsconfig-to-dual-package-example.js",
+  "types": "./module/tsconfig-to-dual-package-example.d.ts",
+  "exports": {
+    ".": {
+      "types": "./module/tsconfig-to-dual-package-example.d.ts",
+      "import": "./module/tsconfig-to-dual-package-example.js",
+      "require": "./lib/tsconfig-to-dual-package-example.js",
+      "default": "./lib/tsconfig-to-dual-package-example.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "bin/",
     "lib/",
@@ -29,15 +39,16 @@
     "src/"
   ],
   "scripts": {
-    "build": "tsc -p ./tsconfig.json",
+    "build": "tsc -p ./tsconfig.json && tsc -p ./tsconfig.cjs.json && tsconfig-to-dual-package",
     "clean": "git clean -fx lib/ module/",
-    "prepublishOnly": "npm run clean && npm run build",
-    "test": "node --test --require ts-node/register ./test/*.ts",
+    "prepublishOnly": "npm run build",
+    "test": "node --test --require ts-node/esm ./test/*.ts",
     "watch": "tsc -p . --watch"
   },
   "devDependencies": {
     "@types/node": "^18.11.18",
     "ts-node": "^10.9.1",
+    "tsconfig-to-dual-package": "^1.0.7",
     "typescript": "^4.9.4"
   },
   "packageManager": "npm@9.2.0"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "build": "tsc -p ./tsconfig.json && tsc -p ./tsconfig.cjs.json && tsconfig-to-dual-package",
     "clean": "git clean -fx lib/ module/",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "npm run clean && npm run build",
     "test": "node --test --loader ts-node/esm ./test/*.ts",
     "watch": "tsc -p . --watch"
   },

--- a/package.json
+++ b/package.json
@@ -20,15 +20,15 @@
   "author": "azu",
   "sideEffects": false,
   "type": "module",
-  "main": "./lib/tsconfig-to-dual-package-example.js",
-  "module": "./module/tsconfig-to-dual-package-example.js",
-  "types": "./module/tsconfig-to-dual-package-example.d.ts",
+  "main": "./lib/index.js",
+  "module": "./module/index.js",
+  "types": "./module/index.d.ts",
   "exports": {
     ".": {
-      "types": "./module/tsconfig-to-dual-package-example.d.ts",
-      "import": "./module/tsconfig-to-dual-package-example.js",
-      "require": "./lib/tsconfig-to-dual-package-example.js",
-      "default": "./lib/tsconfig-to-dual-package-example.js"
+      "types": "./module/index.d.ts",
+      "import": "./module/index.js",
+      "require": "./lib/index.js",
+      "default": "./lib/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { sum } from "./sum";
+export { sum } from "./sum.js";

--- a/test/sum.test.ts
+++ b/test/sum.test.ts
@@ -1,4 +1,4 @@
-import { sum } from "../src";
+import { sum } from "../src/sum.js";
 import { describe, it } from "node:test";
 import assert from "assert";
 describe("sum", function() {

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "./lib/",
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "ESNext",
+    "moduleResolution": "NodeNext",
     "esModuleInterop": true,
     "newLine": "LF",
-    "outDir": "./lib/",
+    "outDir": "./module/",
     "target": "ES2018",
     "sourceMap": true,
     "declaration": true,


### PR DESCRIPTION
This is example migration step for [tsconfig-to-dual-package](https://github.com/azu/tsconfig-to-dual-package)

1. [Install tsconfig-to-dual-package && add type and exports](https://github.com/azu/tsconfig-to-dual-package-example/commit/471f788240ea431d15ed9fab40ba848f1289882d)
2. [Update tsconfig.json for ESM and Add tsconfig.cjs.json for CJS](https://github.com/azu/tsconfig-to-dual-package-example/commit/b9f8998a9479228d5d5a161d7c09bd430a269972)
3. [Use --loader ts-node/esm instead --require ts-node/register](https://github.com/azu/tsconfig-to-dual-package-example/commit/dba7c0252560e38da8558f668969d7635bd9ef47)
4. [Convert source code to ESM](https://github.com/azu/tsconfig-to-dual-package-example/commit/63933d99ba66904e9b28cf84f7ef75b219a78598)

## Test Plan

```
npm run clean
npm run build
npx publint
# tsconfig-to-dual-package-example lint results:
# All good!
```